### PR TITLE
Support running with gem5 in addition to spike

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,15 @@
 
 #Depending on how you test your system you may want to comment, or uncomment
 #the following
-CFLAGS=-fno-stack-protector -z execstack
+CFLAGS=-fno-stack-protector -z execstack -std=gnu11 -static
 
 # RISCV GCC compiler - TODO: auto-detect the right gcc or make it an input
-CC=../riscv-tools-install/multilib/bin/riscv64-unknown-elf-gcc
+NEWLIBERR=$(shell which riscv64-unknown-elf-gcc > /dev/null; echo $$?)
+ifeq "$(NEWLIBERR)" "0"
+	CC=riscv64-unknown-elf-gcc
+else
+	CC=riscv64-unknown-linux-gnu-gcc
+endif
 
 all: attack_generator
 
@@ -16,4 +21,5 @@ clean:
 
 # ATTACK GENERATOR COMPILE
 attack_generator: ./source/attack_generator.c
+	mkdir -p build
 	${CC} ${CFLAGS} ./source/attack_generator.c -o ./build/attack_generator 

--- a/ripe_tester.py
+++ b/ripe_tester.py
@@ -14,8 +14,26 @@
 
 import os
 import sys
+import argparse
 
-spike_path = "/home/nrifel/ripe/riscv-tools-install/riscv/bin/spike"
+parser = argparse.ArgumentParser(description=
+                                 'Run RIPE experiments on spike or gem5.',
+                                 formatter_class=
+                                 argparse.ArgumentDefaultsHelpFormatter)
+parser.add_argument('--sim', action='store', default='spike',
+                    help='Name of simulator (gem5 or spike)')
+parser.add_argument('--attack', action='store', default='direct',
+                    help='Direct or indirect attack or both')
+parser.add_argument('-n', '--num-iterations', action='store', default='1',
+                    help='Number of times to repeat attack')
+
+args = parser.parse_args()
+
+spike_path = "spike"
+pk_path = "pk"
+gem5_path = os.environ['GEM5_ROOT'] + '/build/RISCV/gem5.opt '
+gem5_cfg = os.environ['GEM5_ROOT'] + '/configs/example/se.py'
+gem5_opts = ' --cpu-type=TimingSimpleCPU --mem-size=1GB '
 
 
 code_ptr = ["ret", "funcptrstackparam", "longjmpstackvar", \
@@ -35,22 +53,17 @@ techniques = []
 repeat_times = 0
 
 
-if len(sys.argv) < 2:
-	print "Usage: python "+sys.argv[0] + "[direct|indirect|both] <number of times to repeat each test>"
-	sys.exit(1)
-
+if args.attack == "both":
+   techniques = ["direct","indirect"];
 else:
-	if sys.argv[1] == "both":
-		techniques = ["direct","indirect"];
-	else:
-		techniques = [sys.argv[1]];
+   techniques = [args.attack]
 
-	repeat_times = int(sys.argv[2]);
+repeat_times = int(args.num_iterations)
 
 
 i = 0
-if not os.path.exists("/tmp/ripe-eval"):
-	os.system("mkdir /tmp/ripe-eval");
+if not os.path.exists("./output/" + args.sim):
+    os.system("mkdir -p output/" + args.sim);
 
 total_ok=0;
 total_fail=0;
@@ -59,54 +72,53 @@ total_np = 0;
 
 
 for attack in attacks:
-	for tech in techniques:
-		for loc in locations:
-			for ptr in code_ptr:
-				for func in funcs:
-					i = 0
-					s_attempts = 0
-					attack_possible = 1
-					while i < repeat_times:
-						i += 1
+    for tech in techniques:
+        for loc in locations:
+            for ptr in code_ptr:
+                for func in funcs:
+                    i = 0
+                    s_attempts = 0
+                    attack_possible = 1
+                    while i < repeat_times:
+                        i += 1
 
-						os.system("rm /tmp/ripe_log")
-						cmdline = spike_path + " pk ./build/attack_generator -t "+tech+" -c " + ptr + "  -l " + loc +" -f " + func + ">> /tmp/ripe_log 2>&1"
-						#cmdline = "./build/ripe_attack_generator -t "+tech+" -i "+attack+" -c " + ptr + "  -l " + loc +" -f " + func + " > /tmp/ripe_log 2>&1"
-						os.system(cmdline)
-						log = open("/tmp/ripe_log","r")
-		
-
-						if log.read().find("Impossible") != -1:
-							print cmdline,"\t\t","NOT POSSIBLE"
-							attack_possible = 0;
-							break;	#Not possible once, not possible always :)
+                        logName = "output/" + args.sim + "/ripe_log_" + tech + "_" + ptr + "_" + loc + "_" + func
+                        os.system("rm " + logName)
+                        if args.sim == 'spike':
+                           cmdline = spike_path + " " + pk_path +  " ./build/attack_generator -t "+tech+" -c " + ptr + "  -l " + loc +" -f " + func + ">> " + logName + " 2>&1"
+                        else:
+                           cmdline = gem5_path + gem5_cfg + gem5_opts + " -c build/attack_generator -o '-t " + tech + " -c " + ptr + " -l " + loc + " -f " + func + "' >> " + logName + " 2>&1"
+                        #cmdline = "./build/ripe_attack_generator -t "+tech+" -i "+attack+" -c " + ptr + "  -l " + loc +" -f " + func + " > /tmp/ripe_log 2>&1"
+                        os.system(cmdline)
+                        log = open(logName,"r")
 
 
-						if os.path.exists("urhacked"):
-							s_attempts += 1		
-							os.system("rm -f urhacked")
+                        if log.read().find("Impossible") != -1:
+                            print cmdline,"\t\t","NOT POSSIBLE"
+                            attack_possible = 0;
+                            break;  #Not possible once, not possible always :)
 
 
-					if attack_possible == 0:
-						total_np += 1;
-						continue
+                        if os.path.exists("urhacked"):
+                            s_attempts += 1
+                            os.system("rm -f urhacked")
 
-					if s_attempts == repeat_times:
-						print cmdline,"\t\tOK\t", s_attempts,"/",repeat_times
-						total_ok += 1;
-					elif s_attempts == 0:
-						print cmdline,"\t\tFAIL\t",s_attempts,"/",repeat_times
-						total_fail += 1;
-					else:
-						print cmdline,"\t\tSOMETIMES\t", s_attempts,"/",repeat_times
-						total_some +=1;
-						
+
+                    if attack_possible == 0:
+                        total_np += 1;
+                        continue
+
+                    if s_attempts == repeat_times:
+                        print cmdline,"\t\tOK\t", s_attempts,"/",repeat_times
+                        total_ok += 1;
+                    elif s_attempts == 0:
+                        print cmdline,"\t\tFAIL\t",s_attempts,"/",repeat_times
+                        total_fail += 1;
+                    else:
+                        print cmdline,"\t\tSOMETIMES\t", s_attempts,"/",repeat_times
+                        total_some +=1;
 
 total_attacks = total_ok + total_some + total_fail + total_np;
 print "\n||Summary|| OK: ",total_ok," ,SOME: ",total_some," ,FAIL: ",total_fail," ,NP: ",total_np," ,Total Attacks: ",total_attacks
-
-						
-					
-
 
 

--- a/source/attack_generator.c
+++ b/source/attack_generator.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
 #include <setjmp.h>
@@ -81,7 +82,7 @@ int main(int argc, char **argv) {
 
 char* generate_payload() {
 
-  size_t total_size = (uintptr_t) payload.target_addr - (uintptr_t) payload.buffer + sizeof(int);
+  size_t total_size = (uintptr_t) payload.target_addr - (uintptr_t) payload.buffer + sizeof(uintptr_t);
 
   char* temp_char_buffer = (char*) malloc(total_size);
 
@@ -89,11 +90,11 @@ char* generate_payload() {
     fprintf(stderr, "malloc failed\n");
   }
 
-  int overflow_ptr = (int) payload.overflow_ptr;
+  void* overflow_ptr = (void*) payload.overflow_ptr;
   memcpy(temp_char_buffer, payload.contents, payload.size);
 
-  char* tc_ra_location = (char*) ((uintptr_t) temp_char_buffer + total_size - sizeof(int));
-  memcpy(tc_ra_location, &overflow_ptr, sizeof(int));
+  char* tc_ra_location = (char*) ((uintptr_t) temp_char_buffer + total_size - sizeof(uintptr_t));
+  memcpy(tc_ra_location, &overflow_ptr, sizeof(uintptr_t));
 
   payload.size = total_size;
 


### PR DESCRIPTION
Includes a bug fix in copying the full 64-bits of pointer. Creates output folder of log files instead of deleting ripe_log per attack.